### PR TITLE
added support in dynamic types to sproc

### DIFF
--- a/DocumentDBSudio/TreeNodes.cs
+++ b/DocumentDBSudio/TreeNodes.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //-----------------------------------------------------------------------------
 
+using Newtonsoft.Json.Linq;
 namespace Microsoft.Azure.DocumentDBStudio
 {
     using System;
@@ -929,9 +930,17 @@ namespace Microsoft.Azure.DocumentDBStudio
                         }//while
                     }//usi
                 }
-                StoredProcedureResponse<string> rr = await this.client.ExecuteStoredProcedureAsync<string>((this.Tag as Documents.Resource).SelfLink,
-                    inputParamters.ToArray());
-                string json = rr.Response;
+                var dynamicInputParams = new dynamic[inputParamters.Count];
+                for (var i = 0; i < inputParamters.Count; i++)
+                {
+                    var inputParamter = inputParamters[i];
+                    var jTokenParam = JToken.Parse(inputParamter);
+                    var dynamicParam = Helper.ConvertJTokenToDynamic(jTokenParam);
+                    dynamicInputParams[i] = dynamicParam;
+                }
+                StoredProcedureResponse<dynamic> rr = await this.client.ExecuteStoredProcedureAsync<dynamic>((this.Tag as Documents.Resource).SelfLink,
+                   dynamicInputParams);
+                string json = rr.Response.ToString();
 
                 Program.GetMain().SetResultInBrowser(json, null, true, rr.ResponseHeaders);
 


### PR DESCRIPTION
Hey man.
i added support to dynamic parameters sent to the stored procedures . 
this way you can enter values like ["val1","val2"] or {"key1"="val1","key2"="val2"} and receive them as array or object in the stored procedure javascript function.

in addition, you will be able to accept dynamic return value from the stored procedure.
