### PR TITLE
Fix inconsistency for AnyCPU target

### DIFF
--- a/DocumentDBStudio/DocumentDBStudio.csproj
+++ b/DocumentDBStudio/DocumentDBStudio.csproj
@@ -44,7 +44,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
     <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>


### PR DESCRIPTION
The _Platform target_ of the `AnyCPU` was mistakenly set to`x86`, whereas it should be set to `AnyCPU` too. 
