### PR TITLE
Added automatic resolving of MediaType for document attachments.

### DIFF
--- a/DocumentDBStudio/DocumentDBStudio.csproj
+++ b/DocumentDBStudio/DocumentDBStudio.csproj
@@ -18,6 +18,8 @@
     </UpgradeBackupLocation>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile />
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <NuGetPackageImportStamp>daf4999b</NuGetPackageImportStamp>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -32,8 +34,6 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <NuGetPackageImportStamp>daf4999b</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -101,6 +101,10 @@
       <HintPath>..\packages\Microsoft.Azure.DocumentDB.1.10.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="MimeSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MimeSharp.1.0.0\lib\MimeSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/DocumentDBStudio/TreeNodes.cs
+++ b/DocumentDBStudio/TreeNodes.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //-----------------------------------------------------------------------------
 
+using MimeSharp;
+
 namespace Microsoft.Azure.DocumentDBStudio
 {
     using System;
@@ -1426,10 +1428,10 @@ namespace Microsoft.Azure.DocumentDBStudio
 
             if (dr == DialogResult.OK)
             {
+                var mime = new Mime();
+                var contentType = mime.Lookup(ofd.FileName);
                 string filename = ofd.FileName;
-                // 
-                // todo: present the dialog for Slug name and Content type
-                // 
+
                 Program.GetMain().SetLoadingState();
 
                 try
@@ -1440,7 +1442,7 @@ namespace Microsoft.Azure.DocumentDBStudio
                     {
                         MediaOptions mediaOptions = new MediaOptions()
                         {
-                            ContentType = "application/octet-stream",
+                            ContentType = contentType,
                             Slug = Path.GetFileName(ofd.FileName)
                         };
 

--- a/DocumentDBStudio/TreeNodes.cs
+++ b/DocumentDBStudio/TreeNodes.cs
@@ -2,8 +2,6 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //-----------------------------------------------------------------------------
 
-using MimeSharp;
-
 namespace Microsoft.Azure.DocumentDBStudio
 {
     using System;
@@ -19,6 +17,7 @@ namespace Microsoft.Azure.DocumentDBStudio
     using Microsoft.Azure.DocumentDBStudio.Properties;
     using Microsoft.Azure.Documents.Client;
     using Microsoft.Azure.Documents.Linq;
+    using MimeSharp;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using Newtonsoft.Json.Serialization;

--- a/DocumentDBStudio/packages.config
+++ b/DocumentDBStudio/packages.config
@@ -5,5 +5,6 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net45" />
+  <package id="MimeSharp" version="1.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
See my PR for adding automatic resolving of MediaType for document attachments by using the MimeSharp NuGet package. I think this is a usefulle addition to the project because attachments now always use the default application/octet-stream MediaType.
