### PR TITLE
Update PrettyPrintJSONTemplate to handle UTF8

### DIFF
--- a/DocumentDBStudio/Resources/prettyJSON/PrettyPrintJSONTemplate.html
+++ b/DocumentDBStudio/Resources/prettyJSON/PrettyPrintJSONTemplate.html
@@ -2,6 +2,7 @@
 <head>
     <title>PrettyPrintJSON</title>
     <meta http-equiv="X-UA-Compatible" content="IE=9" />
+    <meta http-equiv="Content-Type" content="content-type=text/html; charset=utf-8" />
     <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Quicksand" />
     <link rel="stylesheet" type="text/css" href="pretty-json.css" />
 


### PR DESCRIPTION
UTF8 characters were not rendering correctly in the tool, which looked like a problem with IE.  Added meta tag to fix.