### PR TITLE
Make document creation options available from Document context menu + Introduce functionality to paste a new document from clipboard +  	Add several more shortcut keys

### DIFF
--- a/DocumentDBStudio/MainForm.cs
+++ b/DocumentDBStudio/MainForm.cs
@@ -791,8 +791,12 @@ namespace Microsoft.Azure.DocumentDBStudio
         }
 
         internal void SetCrudContext(
-            TreeNode node, OperationType operation, ResourceType resourceType, string bodytext, 
-            Action<object, RequestOptions> func, CommandContext commandContext = null
+            TreeNode node, 
+            OperationType operation, 
+            ResourceType resourceType, 
+            string bodytext, 
+            Action<object, RequestOptions> func, 
+            CommandContext commandContext = null
         )
         {
             if (commandContext == null)
@@ -808,6 +812,7 @@ namespace Microsoft.Azure.DocumentDBStudio
             tabCrudContext.Text = string.Format("{0} {1}", operation, resourceType);
             tbCrudContext.Text = bodytext;
 
+            SetToolStripBtnExecuteTooltip(true);
             toolStripBtnExecute.Enabled = true;
             tbCrudContext.ReadOnly = commandContext.IsDelete;
 
@@ -851,6 +856,7 @@ namespace Microsoft.Azure.DocumentDBStudio
             if (this.resourceType == ResourceType.DocumentCollection && (operationType == OperationType.Create || operationType == OperationType.Replace))
             {
                 tabControl.TabPages.Insert(0, tabDocumentCollection);
+                SetToolStripBtnExecuteTooltip();
                 if (operationType == OperationType.Create)
                 {
                     tbCollectionId.Enabled = true;
@@ -945,6 +951,11 @@ namespace Microsoft.Azure.DocumentDBStudio
             }
 
             return true;
+        }
+
+        public void SetToolStripBtnExecuteTooltip(bool includeF5 = false)
+        {
+            toolStripBtnExecute.ToolTipText = includeF5 ? "Execute (F5)" : "Execute";
         }
 
         private void toolStripBtnExecute_Click(object sender, EventArgs e)

--- a/DocumentDBStudio/Nodes/DatabaseAccountNode.cs
+++ b/DocumentDBStudio/Nodes/DatabaseAccountNode.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Azure.DocumentDBStudio
             Nodes.Add(new OfferNode(_client));
 
             AddMenuItem("Read DatabaseAccount", myMenuItemReadDatabaseAccount_Click);
-            AddMenuItem("Create Database", myMenuItemCreateDatabase_Click);
-            AddMenuItem("Refresh Databases feed", (sender, e) => Refresh(true));
-            AddMenuItem("Query Database", myMenuItemQueryDatabase_Click);
+            AddMenuItem("Create Database", myMenuItemCreateDatabase_Click, Shortcut.CtrlN);
+            AddMenuItem("Refresh Databases feed", (sender, e) => Refresh(true), Shortcut.F5);
+            AddMenuItem("Query Database", myMenuItemQueryDatabase_Click, Shortcut.CtrlQ);
 
             _contextMenu.MenuItems.Add("-");
 
@@ -49,11 +49,18 @@ namespace Microsoft.Azure.DocumentDBStudio
             this.Collapse();
         }
 
-        private void AddMenuItem(string menuItemText, EventHandler eventHandler)
+        private MenuItem AddMenuItem(string menuItemText, EventHandler eventHandler, Shortcut shortcut = Shortcut.None)
         {
             var menuItem = new MenuItem(menuItemText);
             menuItem.Click += eventHandler;
+            if (shortcut != Shortcut.None)
+            {
+                menuItem.Shortcut = shortcut;
+            }
+
             _contextMenu.MenuItems.Add(menuItem);
+
+            return menuItem;
         }
 
         void myMenuItemChangeSetting_Click(object sender, EventArgs e)
@@ -90,6 +97,11 @@ namespace Microsoft.Azure.DocumentDBStudio
         void myMenuItemCreateDatabase_Click(object sender, EventArgs e)
         {
             // 
+            InvokeCreateDatabase();
+        }
+
+        private void InvokeCreateDatabase()
+        {
             dynamic d = new System.Dynamic.ExpandoObject();
             d.id = "Here is your Database Id";
             string x = JsonConvert.SerializeObject(d, Formatting.Indented);
@@ -98,7 +110,13 @@ namespace Microsoft.Azure.DocumentDBStudio
 
         void myMenuItemQueryDatabase_Click(object sender, EventArgs e)
         {
-            Program.GetMain().SetCrudContext(this, OperationType.Query, ResourceType.Database, "select * from c", QueryDatabasesAsync);
+            InvokeQueryDatabase();
+        }
+
+        private void InvokeQueryDatabase()
+        {
+            Program.GetMain()
+                .SetCrudContext(this, OperationType.Query, ResourceType.Database, "select * from c", QueryDatabasesAsync);
         }
 
         void myMenuItemRemoveDatabaseAccount_Click(object sender, EventArgs e)
@@ -238,6 +256,23 @@ namespace Microsoft.Azure.DocumentDBStudio
 
         public override void HandleNodeKeyDown(object sender, KeyEventArgs keyEventArgs)
         {
+            var kv = keyEventArgs.KeyValue;
+            var ctrl = keyEventArgs.Control;
+
+            if (ctrl && kv == 78) // ctrl+n
+            {
+                InvokeCreateDatabase();
+            }
+
+            if (ctrl && kv == 81) // ctrl+q
+            {
+                InvokeQueryDatabase();
+            }
+
+            if (kv == 116) // F5
+            {
+                Refresh(true);
+            }
         }
 
         public override void HandleNodeKeyPress(object sender, KeyPressEventArgs keyPressEventArgs)

--- a/DocumentDBStudio/Nodes/DocumentCollectionNode.cs
+++ b/DocumentDBStudio/Nodes/DocumentCollectionNode.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.DocumentDBStudio
             AddMenuItem("Read DocumentCollection", myMenuItemReadDocumentCollection_Click);
 
             AddMenuItem("Replace DocumentCollection", myMenuItemReplaceDocumentCollection_Click);
-            AddMenuItem("Delete DocumentCollection", myMenuItemDeleteDocumentCollection_Click);
+            AddMenuItem("Delete DocumentCollection", myMenuItemDeleteDocumentCollection_Click, Shortcut.Del);
 
             _contextMenu.MenuItems.Add("-");
             
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.DocumentDBStudio
             _contextMenu.MenuItems.Add("-");
 
             AddMenuItem("Refresh Documents feed", (sender, e) => Refresh(true), Shortcut.F5);
-            AddMenuItem("Query Documents", myMenuItemQueryDocument_Click);
+            AddMenuItem("Query Documents", myMenuItemQueryDocument_Click, Shortcut.CtrlQ);
 
             _contextMenu.MenuItems.Add("-");
             AddMenuItem("Configure Document Listing settings...", myMenuConfigureDocumentListingDisplay_Click);
@@ -139,9 +139,16 @@ namespace Microsoft.Azure.DocumentDBStudio
 
         void myMenuItemDeleteDocumentCollection_Click(object sender, EventArgs e)
         {
+            InvokeDeleteDocumentCollection();
+        }
+
+        private void InvokeDeleteDocumentCollection()
+        {
             var bodytext = Tag.ToString();
             var context = new CommandContext {IsDelete = true};
-            Program.GetMain().SetCrudContext(this, OperationType.Delete, ResourceType.DocumentCollection, bodytext, DeleteDocumentCollectionAsync, context);
+            Program.GetMain()
+                .SetCrudContext(this, OperationType.Delete, ResourceType.DocumentCollection, bodytext,
+                    DeleteDocumentCollectionAsync, context);
         }
 
         void myMenuItemReplaceDocumentCollection_Click(object sender, EventArgs e)
@@ -332,12 +339,19 @@ namespace Microsoft.Azure.DocumentDBStudio
 
         void myMenuItemQueryDocument_Click(object sender, EventArgs e)
         {
+            InvokeQueryDocuments();
+        }
+
+        public void InvokeQueryDocuments()
+        {
             _currentQueryCommandContext = new CommandContext {IsFeed = true};
 
             // reset continuation token
             _currentContinuation = null;
 
-            Program.GetMain().SetCrudContext(this, OperationType.Query, ResourceType.Document, "select * from c", QueryDocumentsAsync, _currentQueryCommandContext);
+            Program.GetMain()
+                .SetCrudContext(this, OperationType.Query, ResourceType.Document, "select * from c", QueryDocumentsAsync,
+                    _currentQueryCommandContext);
         }
 
         async void CreateDocumentAsync(object resource, RequestOptions requestOptions)
@@ -547,6 +561,12 @@ namespace Microsoft.Azure.DocumentDBStudio
             var ctrl = keyEventArgs.Control;
             var shift = keyEventArgs.Shift;
 
+            if (kv == 46) // del
+            {
+                InvokeDeleteDocumentCollection();
+            }
+
+
             if (kv == 116) // F5
             {
                 Refresh(true);
@@ -555,6 +575,11 @@ namespace Microsoft.Azure.DocumentDBStudio
             if (ctrl && kv == 78) // ctrl+n
             {
                 InvokeCreateDocument();
+            }
+
+            if (ctrl && kv == 81) // ctrl+q
+            {
+                InvokeQueryDocuments();
             }
 
             if (ctrl && shift && kv == 78) // ctrl+n
@@ -566,6 +591,9 @@ namespace Microsoft.Azure.DocumentDBStudio
             {
                 InvokeCreateNewDocumentBasedOnClipboard();
             }
+
+
+            
 
         }
 

--- a/DocumentDBStudio/Nodes/DocumentCollectionNode.cs
+++ b/DocumentDBStudio/Nodes/DocumentCollectionNode.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft.Azure.DocumentDBStudio.CustomDocumentListDisplay;
 using Microsoft.Azure.DocumentDBStudio.Helpers;
@@ -200,6 +201,11 @@ namespace Microsoft.Azure.DocumentDBStudio
 
         void myMenuItemCreateDocumentFromFile_Click(object sender, EventArgs e)
         {
+            InvokeCreateDocumentFromFile();
+        }
+
+        public void InvokeCreateDocumentFromFile()
+        {
             var ofd = new OpenFileDialog();
             var dr = ofd.ShowDialog();
 
@@ -215,17 +221,22 @@ namespace Microsoft.Azure.DocumentDBStudio
 
         async void myMenuItemCreateDocumentsFromFolder_Click(object sender, EventArgs e)
         {
+            await InvokeCreateDocumentsFromFolder();
+        }
+
+        public async Task InvokeCreateDocumentsFromFolder()
+        {
             var ofd = new OpenFileDialog {Multiselect = true};
 
             var dr = ofd.ShowDialog();
 
             if (dr == DialogResult.OK)
             {
-                var status = string.Format(CultureInfo.InvariantCulture, "Create {0} documents in collection\r\n", ofd.FileNames.Length);
+                var status = string.Format(CultureInfo.InvariantCulture, "Create {0} documents in collection\r\n",
+                    ofd.FileNames.Length);
                 // Read the files 
                 foreach (var filename in ofd.FileNames)
                 {
-
                     // right now assume every file is JSON content
                     var jsonText = File.ReadAllText(filename);
                     var fileRootName = Path.GetFileName(filename);
@@ -236,21 +247,25 @@ namespace Microsoft.Azure.DocumentDBStudio
                     {
                         using (PerfStatus.Start("CreateDocument"))
                         {
-                            var newdocument = await _client.CreateDocumentAsync((Tag as DocumentCollection).GetLink(_client), document, Program.GetMain().GetRequestOptions());
+                            var newdocument =
+                                await
+                                    _client.CreateDocumentAsync((Tag as DocumentCollection).GetLink(_client), document,
+                                        Program.GetMain().GetRequestOptions());
                             status += string.Format(CultureInfo.InvariantCulture, "Succeed adding {0} \r\n", fileRootName);
                         }
                     }
                     catch (DocumentClientException ex)
                     {
-                        status += string.Format(CultureInfo.InvariantCulture, "Failed adding {0}, statusCode={1} \r\n", fileRootName, ex.StatusCode);
+                        status += string.Format(CultureInfo.InvariantCulture, "Failed adding {0}, statusCode={1} \r\n",
+                            fileRootName, ex.StatusCode);
                     }
                     catch (Exception ex)
                     {
-                        status += string.Format(CultureInfo.InvariantCulture, "Failed adding {0}, unknown exception \r\n", fileRootName, ex.Message);
+                        status += string.Format(CultureInfo.InvariantCulture, "Failed adding {0}, unknown exception \r\n",
+                            fileRootName, ex.Message);
                     }
 
                     Program.GetMain().SetResultInBrowser(null, status, false);
-
                 }
             }
         }

--- a/DocumentDBStudio/Nodes/ResourceNode.cs
+++ b/DocumentDBStudio/Nodes/ResourceNode.cs
@@ -109,10 +109,18 @@ namespace Microsoft.Azure.DocumentDBStudio
 
                 if (isDocument)
                 {
+                    _contextMenu.MenuItems.Add("-");
+
                     var createWithnewIdItem = AddMenuItem(
                         string.Format("Create {0} with new id based on this", _resourceType), (sender, e) => InvokeCreateNewDocumentBasedOnSelectedWithNewId()
                     ); 
                     MenuItemHelper.SetCustomShortcut(createWithnewIdItem, Keys.Control | Keys.Alt | Keys.N);
+
+                    AddMenuItem(string.Format("Create {0}", _resourceType), myMenuItemCreateNewDocument_Click, Shortcut.CtrlN);
+                    AddMenuItem(string.Format("Create {0} with prefilled id", _resourceType), myMenuItemCreateNewDocumentWithId_Click, Shortcut.CtrlShiftN);
+                    AddMenuItem("Create Document From File...", myMenuItemCreateDocumentFromFile_Click);
+                    AddMenuItem("Create Multiple Documents From Folder...", myMenuItemCreateDocumentsFromFolder_Click);
+
                 }
             }
 
@@ -166,6 +174,26 @@ namespace Microsoft.Azure.DocumentDBStudio
             }
 
             
+        }
+
+        private void myMenuItemCreateDocumentsFromFolder_Click(object sender, EventArgs e)
+        {
+            ((DocumentCollectionNode)Parent).InvokeCreateDocumentsFromFolder();
+        }
+
+        private void myMenuItemCreateDocumentFromFile_Click(object sender, EventArgs e)
+        {
+            ((DocumentCollectionNode)Parent).InvokeCreateDocumentFromFile();
+        }
+
+        private void myMenuItemCreateNewDocument_Click(object sender, EventArgs e)
+        {
+            ((DocumentCollectionNode) Parent).InvokeCreateDocument();
+        }
+
+        private void myMenuItemCreateNewDocumentWithId_Click(object sender, EventArgs e)
+        {
+            ((DocumentCollectionNode)Parent).InvokeCreatedDocumentWithId();
         }
 
         private MenuItem AddMenuItem(string menuItemText, EventHandler eventHandler, Shortcut shortcut = Shortcut.None)

--- a/DocumentDBStudio/Nodes/ResourceNode.cs
+++ b/DocumentDBStudio/Nodes/ResourceNode.cs
@@ -118,8 +118,10 @@ namespace Microsoft.Azure.DocumentDBStudio
 
                     AddMenuItem(string.Format("Create {0}", _resourceType), myMenuItemCreateNewDocument_Click, Shortcut.CtrlN);
                     AddMenuItem(string.Format("Create {0} with prefilled id", _resourceType), myMenuItemCreateNewDocumentWithId_Click, Shortcut.CtrlShiftN);
-                    AddMenuItem("Create Document From File...", myMenuItemCreateDocumentFromFile_Click);
-                    AddMenuItem("Create Multiple Documents From Folder...", myMenuItemCreateDocumentsFromFolder_Click);
+                    AddMenuItem(string.Format("Create {0} from File...", _resourceType), myMenuItemCreateDocumentFromFile_Click);
+                    AddMenuItem(string.Format("Create Multiple {0}s from Folder...", _resourceType), myMenuItemCreateDocumentsFromFolder_Click);
+                    _contextMenu.MenuItems.Add("-");
+                    AddMenuItem(string.Format("Paste {0} from clipboard", _resourceType), (sender, e) => InvokeCreateNewDocumentBasedOnClipboard(), Shortcut.CtrlV);
 
                 }
             }
@@ -1092,6 +1094,13 @@ namespace Microsoft.Azure.DocumentDBStudio
             }
         }
 
+        private void InvokeCreateNewDocumentBasedOnClipboard()
+        {
+            if (Parent is DocumentCollectionNode)
+            {
+                (Parent as DocumentCollectionNode).InvokeCreateNewDocumentBasedOnClipboard();
+            }
+        }
 
         public override void HandleNodeKeyDown(object sender, KeyEventArgs keyEventArgs)
         {
@@ -1099,6 +1108,7 @@ namespace Microsoft.Azure.DocumentDBStudio
             var ctrl = keyEventArgs.Control;
             var shift = keyEventArgs.Shift;
             var alt = keyEventArgs.Alt;
+
 
             if (kv == 46) // del
             {
@@ -1149,6 +1159,11 @@ namespace Microsoft.Azure.DocumentDBStudio
                 if (ctrl && alt && kv == 78) // ctrl+alt+n
                 {
                     InvokeCreateNewDocumentBasedOnSelectedWithNewId();
+                }
+
+                if (ctrl && kv == 86) // ctrl+v
+                {
+                    dcn.InvokeCreateNewDocumentBasedOnClipboard();
                 }
             }
 

--- a/DocumentDBStudio/Nodes/ResourceNode.cs
+++ b/DocumentDBStudio/Nodes/ResourceNode.cs
@@ -1161,6 +1161,11 @@ namespace Microsoft.Azure.DocumentDBStudio
                     InvokeCreateNewDocumentBasedOnSelectedWithNewId();
                 }
 
+                if (ctrl && kv == 81) // ctrl+q
+                {
+                    dcn.InvokeQueryDocuments();
+                }
+
                 if (ctrl && kv == 86) // ctrl+v
                 {
                     dcn.InvokeCreateNewDocumentBasedOnClipboard();

--- a/DocumentDBStudio/Nodes/StoredProcedureNode.cs
+++ b/DocumentDBStudio/Nodes/StoredProcedureNode.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.DocumentDBStudio
                 _contextMenu.MenuItems.Add(menuItem);
             }
             {
-                var menuItem = new MenuItem("Create StoredProcedure From File");
+                var menuItem = new MenuItem("Create StoredProcedure from File");
                 menuItem.Click += myMenuItemCreateStoredProcedureFromFile_Click;
                 _contextMenu.MenuItems.Add(menuItem);
             }


### PR DESCRIPTION
This pull request contains the following new functionality:

* Document creation options are now available from the Document context menu. The point of this is to make the shortcut options more obvious as well as not having to go up to the top of the list and click on the parent node if you are in a large collection of documents.

* There is now a new option to paste a document from the clipboard, either via the context menu or by using ctrl+v. The functionality will verify that the contents of the clipboard is a valid json payload as well as containing an "id" node with a valid guid value before allowing the contents to be pasted into the creation window.

* Several new shortcut keys has been added.