### PR TITLE
Check box to avoid persisting account information + bug fix

### DIFF
--- a/DocumentDBStudio/AccountSettingsForm.Designer.cs
+++ b/DocumentDBStudio/AccountSettingsForm.Designer.cs
@@ -42,6 +42,7 @@
             this.radioButtonGateway = new System.Windows.Forms.RadioButton();
             this.cbNameBased = new System.Windows.Forms.CheckBox();
             this.cbEnableEndpointDiscovery = new System.Windows.Forms.CheckBox();
+            this.persistLocallyCheckBox = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -60,7 +61,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tbAccountSecret.Location = new System.Drawing.Point(144, 80);
             this.tbAccountSecret.Name = "tbAccountSecret";
-            this.tbAccountSecret.Size = new System.Drawing.Size(244, 20);
+            this.tbAccountSecret.Size = new System.Drawing.Size(342, 20);
             this.tbAccountSecret.TabIndex = 2;
             // 
             // tbAccountName
@@ -69,7 +70,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tbAccountName.Location = new System.Drawing.Point(144, 52);
             this.tbAccountName.Name = "tbAccountName";
-            this.tbAccountName.Size = new System.Drawing.Size(244, 20);
+            this.tbAccountName.Size = new System.Drawing.Size(342, 20);
             this.tbAccountName.TabIndex = 1;
             // 
             // label3
@@ -94,7 +95,7 @@
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOK.Location = new System.Drawing.Point(216, 204);
+            this.btnOK.Location = new System.Drawing.Point(314, 204);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 23);
             this.btnOK.TabIndex = 5;
@@ -106,7 +107,7 @@
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(313, 204);
+            this.btnCancel.Location = new System.Drawing.Point(411, 204);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 6;
@@ -178,29 +179,42 @@
             this.cbNameBased.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cbNameBased.Location = new System.Drawing.Point(15, 208);
             this.cbNameBased.Name = "cbNameBased";
-            this.cbNameBased.Size = new System.Drawing.Size(120, 17);
+            this.cbNameBased.Size = new System.Drawing.Size(114, 17);
             this.cbNameBased.TabIndex = 27;
             this.cbNameBased.Text = "Use legacy selflink";
             this.cbNameBased.UseVisualStyleBackColor = true;
             // 
-            // cbEnableAutomaticFailover
+            // cbEnableEndpointDiscovery
             // 
             this.cbEnableEndpointDiscovery.AllowDrop = true;
             this.cbEnableEndpointDiscovery.AutoSize = true;
             this.cbEnableEndpointDiscovery.Location = new System.Drawing.Point(144, 179);
-            this.cbEnableEndpointDiscovery.Name = "cbEnableAutomaticFailover";
-            this.cbEnableEndpointDiscovery.Size = new System.Drawing.Size(145, 17);
+            this.cbEnableEndpointDiscovery.Name = "cbEnableEndpointDiscovery";
+            this.cbEnableEndpointDiscovery.Size = new System.Drawing.Size(165, 17);
             this.cbEnableEndpointDiscovery.TabIndex = 28;
             this.cbEnableEndpointDiscovery.Text = "Automatic endpoint discovery";
             this.cbEnableEndpointDiscovery.UseVisualStyleBackColor = true;
             // 
-            // SettingsForm
+            // persistLocallyCheckBox
+            // 
+            this.persistLocallyCheckBox.AutoSize = true;
+            this.persistLocallyCheckBox.Checked = true;
+            this.persistLocallyCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.persistLocallyCheckBox.Location = new System.Drawing.Point(144, 208);
+            this.persistLocallyCheckBox.Name = "persistLocallyCheckBox";
+            this.persistLocallyCheckBox.Size = new System.Drawing.Size(151, 17);
+            this.persistLocallyCheckBox.TabIndex = 29;
+            this.persistLocallyCheckBox.Text = "Persist account info locally";
+            this.persistLocallyCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // AccountSettingsForm
             // 
             this.AcceptButton = this.btnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(400, 239);
+            this.ClientSize = new System.Drawing.Size(498, 239);
+            this.Controls.Add(this.persistLocallyCheckBox);
             this.Controls.Add(this.cbEnableEndpointDiscovery);
             this.Controls.Add(this.cbNameBased);
             this.Controls.Add(this.groupBox1);
@@ -212,7 +226,7 @@
             this.Controls.Add(this.label2);
             this.Controls.Add(this.btnOK);
             this.Controls.Add(this.btnCancel);
-            this.Name = "SettingsForm";
+            this.Name = "AccountSettingsForm";
             this.Text = "Account Settings";
             this.Load += new System.EventHandler(this.SettingsForm_Load);
             this.groupBox1.ResumeLayout(false);
@@ -238,5 +252,6 @@
         private System.Windows.Forms.RadioButton radioButtonDirectHttp;
         private System.Windows.Forms.CheckBox cbNameBased;
         private System.Windows.Forms.CheckBox cbEnableEndpointDiscovery;
+        private System.Windows.Forms.CheckBox persistLocallyCheckBox;
     }
 }

--- a/DocumentDBStudio/AccountSettingsForm.cs
+++ b/DocumentDBStudio/AccountSettingsForm.cs
@@ -75,12 +75,12 @@ namespace Microsoft.Azure.DocumentDBStudio
         private void btnOK_Click(object sender, EventArgs e)
         {
             if (string.IsNullOrEmpty(tbAccountName.Text) || string.IsNullOrEmpty(tbAccountSecret.Text))
-                {
-                    MessageBox.Show("Please input the valid account settings", Constants.ApplicationName);
-                    this.DialogResult = DialogResult.None;
-                }
-                this.AccountEndpoint = tbAccountName.Text;
-                this.AccountSettings.MasterKey = tbAccountSecret.Text;
+            {
+                MessageBox.Show("Please input the valid account settings", Constants.ApplicationName);
+                this.DialogResult = DialogResult.None;
+            }
+            this.AccountEndpoint = tbAccountName.Text;
+            this.AccountSettings.MasterKey = tbAccountSecret.Text;
 
             if (this.radioButtonGateway.Checked)
             {
@@ -96,6 +96,8 @@ namespace Microsoft.Azure.DocumentDBStudio
                 this.AccountSettings.ConnectionMode = ConnectionMode.Direct;
                 this.AccountSettings.Protocol = Protocol.Tcp;
             }
+
+            this.AccountSettings.IsPersistedLocally = this.persistLocallyCheckBox.Checked;
 
             this.AccountSettings.EnableEndpointDiscovery = cbEnableEndpointDiscovery.Checked;
             this.AccountSettings.IsNameBased = !cbNameBased.Checked;

--- a/DocumentDBStudio/MainForm.cs
+++ b/DocumentDBStudio/MainForm.cs
@@ -470,10 +470,13 @@ namespace Microsoft.Azure.DocumentDBStudio
 
             if (!found)
             {
-                Settings.Default.AccountSettingsList.Add(accountEndpoint);
-                Settings.Default.AccountSettingsList.Add(JsonConvert.SerializeObject(accountSettings));
+                if (accountSettings.IsPersistedLocally)
+                {
+                    Settings.Default.AccountSettingsList.Add(accountEndpoint);
+                    Settings.Default.AccountSettingsList.Add(JsonConvert.SerializeObject(accountSettings));
 
-                Settings.Default.Save();
+                    Settings.Default.Save();
+                }
 
                 AddConnectionTreeNode(accountEndpoint, accountSettings);
             }
@@ -695,8 +698,8 @@ namespace Microsoft.Azure.DocumentDBStudio
                 // Update the map.
                 DocumentClientExtension.AddOrUpdate(client.ServiceEndpoint.Host, accountSettings.IsNameBased);
 
-                dbaNode.ForeColor = accountSettings.IsNameBased 
-                    ? Color.Green 
+                dbaNode.ForeColor = accountSettings.IsNameBased
+                    ? Color.Green
                     : Color.Blue;
             }
             catch (Exception e)
@@ -791,11 +794,11 @@ namespace Microsoft.Azure.DocumentDBStudio
         }
 
         internal void SetCrudContext(
-            TreeNode node, 
-            OperationType operation, 
-            ResourceType resourceType, 
-            string bodytext, 
-            Action<object, RequestOptions> func, 
+            TreeNode node,
+            OperationType operation,
+            ResourceType resourceType,
+            string bodytext,
+            Action<object, RequestOptions> func,
             CommandContext commandContext = null
         )
         {
@@ -897,7 +900,7 @@ namespace Microsoft.Azure.DocumentDBStudio
                     int throughput;
                     if (!int.TryParse(tbThroughput.Text, NumberStyles.Integer, CultureInfo.CurrentCulture, out throughput))
                     {
-                        MessageBox.Show(this, 
+                        MessageBox.Show(this,
                                         "Offer throughput has to be integer",
                                         Constants.ApplicationName + "\nVersion " + Constants.ProductVersion,
                                         MessageBoxButtons.OK);
@@ -906,7 +909,7 @@ namespace Microsoft.Azure.DocumentDBStudio
 
                     if (throughput % 100 != 0)
                     {
-                        MessageBox.Show(this, 
+                        MessageBox.Show(this,
                                         "Offer throughput has to be multiple of 100",
                                         Constants.ApplicationName + "\nVersion " + Constants.ProductVersion,
                                         MessageBoxButtons.OK);
@@ -918,7 +921,7 @@ namespace Microsoft.Azure.DocumentDBStudio
                         // remove 250K from the internal version
                         if (throughput < 10000)
                         {
-                            MessageBox.Show(this, 
+                            MessageBox.Show(this,
                                             "Offer throughput has to be between 10K and 250K for partitioned collection",
                                             Constants.ApplicationName + "\nVersion " + Constants.ProductVersion,
                                             MessageBoxButtons.OK);
@@ -927,9 +930,9 @@ namespace Microsoft.Azure.DocumentDBStudio
 
                         // now verify partition key
                         string partitionKey = tbPartitionKeyForCollectionCreate.Text;
-                        if (string.IsNullOrEmpty(partitionKey) || partitionKey[0] != '/' || partitionKey[partitionKey.Length -1 ] == ' ')
+                        if (string.IsNullOrEmpty(partitionKey) || partitionKey[0] != '/' || partitionKey[partitionKey.Length - 1] == ' ')
                         {
-                            MessageBox.Show(this, 
+                            MessageBox.Show(this,
                                             "PartitionKey is not in valid format",
                                             Constants.ApplicationName + "\nVersion " + Constants.ProductVersion,
                                             MessageBoxButtons.OK);
@@ -940,7 +943,7 @@ namespace Microsoft.Azure.DocumentDBStudio
                     {
                         if (throughput < 400 || throughput > 10000)
                         {
-                            MessageBox.Show(this, 
+                            MessageBox.Show(this,
                                             "Offer throughput has to be between 400 and 10000 for single partition collection",
                                             Constants.ApplicationName + "\nVersion " + Constants.ProductVersion,
                                             MessageBoxButtons.OK);
@@ -1028,7 +1031,7 @@ namespace Microsoft.Azure.DocumentDBStudio
                     Id = textBoxforId.Text
                 };
                 currentOperationCallback(trigger, requestOptions);
-           }
+            }
 
             else if (resourceType == ResourceType.UserDefinedFunction
                  && (operationType == OperationType.Create || operationType == OperationType.Replace))
@@ -1136,7 +1139,14 @@ namespace Microsoft.Azure.DocumentDBStudio
 
         public void SetResponseHeaders(NameValueCollection responseHeaders)
         {
-            SetResponseHeaders(new List<NameValueCollection> {responseHeaders});
+            List<NameValueCollection> responseHeadersList = null;
+            // responseHeaders = null in case of an exception thrown 
+            if (responseHeaders != null)
+            {
+                responseHeadersList = new List<NameValueCollection> { responseHeaders };
+            }
+
+            SetResponseHeaders(responseHeadersList);
         }
 
         public void SetResponseHeaders(List<NameValueCollection> responseHeaders)
@@ -1542,7 +1552,7 @@ namespace Microsoft.Azure.DocumentDBStudio
                 labelThroughput.Text = "Fixed 1000 RU. 10GB Storage ";
                 tbThroughput.Enabled = false;
                 tbThroughput.Text = "1000";
-             }
+            }
         }
 
         private void rbOfferS3_CheckedChanged(object sender, EventArgs e)

--- a/DocumentDBStudio/Nodes/TreeNodes.cs
+++ b/DocumentDBStudio/Nodes/TreeNodes.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Azure.DocumentDBStudio
         public Protocol Protocol;
         public bool IsNameBased;
         public bool EnableEndpointDiscovery;
+        /// <summary>
+        /// Specifies whether this account settings should be persisted locally  
+        /// </summary>
+        public bool IsPersistedLocally;
     }
 
     public class CommandContext
@@ -67,12 +71,12 @@ namespace Microsoft.Azure.DocumentDBStudio
         StandardElastic
     }
 
-   
 
-    
 
-    
 
-    
+
+
+
+
 
 }


### PR DESCRIPTION
* Add a checkbox to specify whether you would like to persist an account information or not (for security when dealing with the accounts the keys of which are not desired to be stored on disk)
* Fix a null reference on documentclient exception in the form