### PR TITLE
Enabling cross-partition when querying collection to build the docume…

### DIFF
--- a/DocumentDBStudio/Nodes/DocumentCollectionNode.cs
+++ b/DocumentDBStudio/Nodes/DocumentCollectionNode.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.DocumentDBStudio
                 return;
             }
 
-            var query = _client.CreateDocumentQuery<Document>((Tag as DocumentCollection).GetLink(_client), "SELECT TOP 1 * FROM c");
+            var query = _client.CreateDocumentQuery<Document>((Tag as DocumentCollection).GetLink(_client), "SELECT TOP 1 * FROM c", new FeedOptions() { EnableCrossPartitionQuery = true });
             var doc = query.ToList().First();
             var docConverted = JsonConvert.DeserializeObject(DocumentHelper.RemoveInternalDocumentValues(JsonConvert.SerializeObject(doc)));
 


### PR DESCRIPTION
…nt listing settings dialog

Otherwise we get an exception in multi-partition environments. 

(Also, perhaps there could be a global setting to enable cross-partition query for all queries?)